### PR TITLE
[clean] Suggestion: to-html-url を lib 配下にした

### DIFF
--- a/src/components/contributions/by-repo/comments.tsx
+++ b/src/components/contributions/by-repo/comments.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 import {
   PullRequestReviewCommentEventPayload,
   IssueCommentEventPayload,

--- a/src/components/contributions/by-repo/commits.tsx
+++ b/src/components/contributions/by-repo/commits.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { CommitIcon, InfoIcon } from '@primer/octicons-react';
 import { Summary } from '../types';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 
 const Commits = ({ commits }: { commits: Summary['commits'] }) => {
   const count = Object.values(commits).reduce((acc, c) => acc + c.data.length, 0);

--- a/src/components/contributions/by-repo/issues.tsx
+++ b/src/components/contributions/by-repo/issues.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Summary } from '../types';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 import { InfoIcon, IssueClosedIcon, IssueOpenedIcon } from '@primer/octicons-react';
 
 const Issues = ({ issues }: { issues: Summary['issues'] }) => {

--- a/src/components/contributions/by-repo/pullrequests.tsx
+++ b/src/components/contributions/by-repo/pullrequests.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Summary } from '../types';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 import { GitMergeIcon, GitPullRequestClosedIcon, GitPullRequestIcon, InfoIcon } from '@primer/octicons-react';
 
 const PullRequests = ({ pullRequests }: { pullRequests: Summary['pullRequests'] }) => {

--- a/src/components/contributions/by-repo/repositories.tsx
+++ b/src/components/contributions/by-repo/repositories.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { InfoIcon, RepoIcon } from '@primer/octicons-react';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 import { GitHubEvent } from '../types';
 
 const Repositories = ({ repositories }: { repositories: GitHubEvent[] }) => {

--- a/src/components/contributions/by-repo/stared.tsx
+++ b/src/components/contributions/by-repo/stared.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { InfoIcon, StarFillIcon } from '@primer/octicons-react';
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../../../lib/to-html-url';
 import { GitHubEvent } from '../types';
 
 const StaredRepositories = ({ repositories }: { repositories: GitHubEvent[] }) => {

--- a/src/components/contributions/contributions-simple.tsx
+++ b/src/components/contributions/contributions-simple.tsx
@@ -13,7 +13,7 @@ import type {
   PushEventPayload,
   WatchEventPayload,
 } from './types';
-import { toHtmlUrl } from './contributions';
+import { toHtmlUrl } from '../../lib/to-html-url';
 
 type Props = {
   result: any;

--- a/src/components/contributions/contributions.tsx
+++ b/src/components/contributions/contributions.tsx
@@ -4,10 +4,6 @@ import ContributionsByEvent from './contributions-by-event';
 import ContributionsSimple from './contributions-simple';
 import { Commit, GitHubEvent } from './types';
 
-export const toHtmlUrl = (url: string) => {
-  return url.replace('api.github.com/repos', 'github.com');
-};
-
 type Props = {
   result: any;
   user: string;

--- a/src/lib/__tests__/to-html-url.tsx
+++ b/src/lib/__tests__/to-html-url.tsx
@@ -1,4 +1,4 @@
-import { toHtmlUrl } from '../contributions';
+import { toHtmlUrl } from '../to-html-url';
 
 describe('toHtmlUrl', () => {
   test('check replace', () => {

--- a/src/lib/to-html-url.ts
+++ b/src/lib/to-html-url.ts
@@ -1,0 +1,3 @@
+export const toHtmlUrl = (url: string) => {
+    return url.replace('api.github.com/repos', 'github.com');
+};


### PR DESCRIPTION
## Changed

- `./src/components/contributions/contributions.tsx` に存在していた `toHtmlUrl` を `./src/lib/to-html-url.ts` へ移動