### PR TITLE
[fix] Suggestion: useEffect の依存関係を追加

### DIFF
--- a/pages/timer/index.tsx
+++ b/pages/timer/index.tsx
@@ -203,7 +203,7 @@ const Timer: NextPage = () => {
     }, 200);
 
     return () => clearInterval(interval);
-  }, [count, elapsedMs, decrement, startMs, paused, writeToCanvas]);
+  }, [count, elapsedMs, decrement, startMs, paused, writeToCanvas, maxCount]);
 
   return (
     <>

--- a/src/components/kusa/contributions/contributions.tsx
+++ b/src/components/kusa/contributions/contributions.tsx
@@ -42,7 +42,7 @@ const Contributions = (props: Props) => {
     } else {
       setApiResult(props.result);
     }
-  }, [exclude]);
+  }, [exclude, props.result]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setExclude(e.target.checked);


### PR DESCRIPTION
## Changed

下記の対応を実施

```
React Hook useEffect has a missing dependency: 'props.result'. Either include it or remove the dependency array. If 'setApiResult' needs the current value of 'props.result', you can also switch to useReducer instead of useState and read 'props.result' in the reducer.eslintreact-hooks/exhaustive-deps
```