### PR TITLE
Contribution画像の差し替え

### DIFF
--- a/pages/kusa/[username].tsx
+++ b/pages/kusa/[username].tsx
@@ -102,7 +102,7 @@ const Detail = ({ username }: { username: string }) => {
 
 const Kusa = (props: Props) => {
   const username = props.username;
-  const imgUrl = `https://grass-graph.appspot.com/images/${username}.png?${Date.now()}`;
+  const imgUrl = `https://ksua-image.deno.dev/?user=${username}`;
   const siteUrl = `https://tools.swfz.io/kusa/${username}`;
   const title = `GitHub Contributions(kusa) in ${username}`;
   const desc = `Today: ${props.todayContributionCount}, Yesterday: ${props.yesterdayContributionCount}, Streak: ${props.currentStreak}`;


### PR DESCRIPTION
Contributionグラフが表示されなくなってしまったので代替のサービスを用意しリクエスト先を変更