### PR TITLE
fix: kusaページでAPI応答が不正な場合にクラッシュする問題を修正

### DIFF
--- a/pages/kusa/[username].tsx
+++ b/pages/kusa/[username].tsx
@@ -41,6 +41,11 @@ const fetchContribution = async (url: string, username: string, to: string): Pro
 
   const json = await res.json();
 
+  if (!json.contributions || !Array.isArray(json.contributions) || json.contributions.length === 0) {
+    console.log('Unexpected contributions format:', json);
+    return [null, null];
+  }
+
   if (!to) {
     console.log(json.contributions.at(-1));
   }
@@ -75,9 +80,9 @@ export const getServerSideProps = async (
   console.log(Intl.DateTimeFormat().resolvedOptions().timeZone, [todayContributionCount, yesterdayContributionCount]);
 
   if (
-    todayContributionCount === null ||
-    yesterdayContributionCount === null ||
-    contributions.some((c: number | null) => c === null)
+    todayContributionCount == null ||
+    yesterdayContributionCount == null ||
+    contributions.some((c: number | null) => c == null)
   ) {
     return {
       props: {
@@ -99,7 +104,14 @@ export const getServerSideProps = async (
 const createQueryFn = (username: string) => {
   const fetchEvents = async ({ pageParam = 1 }) => {
     const res = await fetch(`https://api.github.com/users/${username}/events?per_page=100&page=${pageParam}`);
-    return res.json();
+
+    if (!res.ok) {
+      console.log(`Failed to fetch events: ${res.status}`);
+      return [];
+    }
+
+    const json = await res.json();
+    return Array.isArray(json) ? json : [];
   };
 
   return fetchEvents;


### PR DESCRIPTION
## 概要

`/kusa/[username]` ページで外部APIが不正なレスポンスを返した際にページがクラッシュする問題を修正

## Why

外部API（GitHub Contributions API、GitHub Events API）がエラーレスポンスやデータ不足のレスポンスを返した場合、レスポンス検証が不十分でクラッシュするケースがあった

- `fetchContribution`: `json.contributions`が存在しない・空の場合に`.flat()`でクラッシュ
- `createQueryFn`: `res.ok`チェックがなく、レートリミット(403)やユーザー未検出(404)時にエラーオブジェクトが配列として扱われ後続処理でクラッシュ
- `getServerSideProps`: 空配列からのdestructureで`undefined`になった値が`=== null`チェックをすり抜け

## How

1. **`fetchContribution`**: `json.contributions`が配列でない/空の場合に`[null, null]`を返すバリデーション追加
2. **`createQueryFn`（Events API）**: `res.ok`チェックを追加し、エラー時やレスポンスが配列でない場合に空配列を返すよう修正
3. **`getServerSideProps`のnullチェック**: `=== null`を`== null`に変更し`undefined`も捕捉

## 確認観点

- [x] `pnpm lint` でエラーなし（既存のwarningのみ）
- [x] `pnpm test:ci` で全テストパス（8 suites, 80 tests）
- [x] 正常系（APIが正しいレスポンスを返す場合）の挙動に影響がないこと