### PR TITLE
chore: sync renovate config from github-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,29 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    ":pinDevDependencies",
+    "security:openssf-scorecard",
+    "abandonments:recommended"
+  ],
   "minimumReleaseAge": "7 days",
   "internalChecksFilter": "strict",
-  "osvVulnerabilityAlerts": true
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security", "renovate"]
+  },
+  "labels": ["renovate"],
+  "packageRules": [
+    {
+      "matchDatasources": ["npm"],
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "minimumReleaseAge": "14 days",
+      "labels": ["renovate", "automerge"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
Automated file sync by gh-infra FileSet `swfz/article-search+article-search-updater+child-english-study+chrome-extension-copy-markdown-and-hatenablog-embed-link+chrome-extension-dom-links-extractor+chrome-extension-google-slide-usertool-comment-stream+chrome-extension-raindrop-pocket+chrome-extension-slide-comment-stream+chrome-extension-table2csv+claude-bridge+deno-kusa-image+deno-kv-logviewer+deno-logviewer-import-dataform+deno-terminal-image+dotfiles+failed-log-to-slack-action+gh-action-sample+gh-annotations+gh-ap+gh-deps+git-hooks+github-actions-playground+github-actions-sample+github-config+github-projects-import-dataform+googleslide-comme-stream-develop+hatenablog-all-feed-generator+hatenablog_publisher+markdown-sentence-sentiment+memo+memo-collector+memo-dataform+metrics-collector+myself-release-note+notion-import-dataform+obsidian-dataform+obsidian-opener+obsidian-vault+pocket-exporter-dataform+pokego-gym-defence+pokego-to-lv80+private-portal+scraping-codes+self-dashboard+self-dashboard-dataform+slack-to-obsidian-memos-merge+swfz+til+til-collector+timetracker+timetracker-dataform+toggl-to-pixela-cloud-workflows+tools+what_recent`.