### PR TITLE
chore(deps): swfz fork から Gamesight/slack-workflow-status v2.0.0 に差し替え

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
     name: post slack
     runs-on: ubuntu-latest
     steps:
-      - uses: swfz/slack-workflow-status@e6d0c984ad7d32737692508f1a4e4390f16e8fdd # v1.4.0
+      - uses: Gamesight/slack-workflow-status@2e709ce51fd47f02b7221db8547e6e6f49f81f1d # v2.0.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,7 +42,7 @@ jobs:
     name: post slack
     runs-on: ubuntu-latest
     steps:
-      - uses: swfz/slack-workflow-status@e6d0c984ad7d32737692508f1a4e4390f16e8fdd # v1.4.0
+      - uses: Gamesight/slack-workflow-status@2e709ce51fd47f02b7221db8547e6e6f49f81f1d # v2.0.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
## 概要

GitHub Actions の Slack 通知で使っていた `swfz/slack-workflow-status` (fork) を、 upstream の `Gamesight/slack-workflow-status@v2.0.0` に差し替える。

## Why

- 元々 fork していた理由は `workflow_run` イベントに対応するためだった
- upstream で v2.0.0 がリリースされ、 `workflow_run` が公式 input としてサポートされた ([README](https://github.com/Gamesight/slack-workflow-status/blob/v2.0.0/README.md))
- fork を維持し続けるとセキュリティパッチや機能追加への追従コストが発生し続けるため、 upstream に戻すのが合理的

## How

`.github/workflows/` 配下の `uses:` を一括置換:

- before: `swfz/slack-workflow-status@e6d0c984ad7d32737692508f1a4e4390f16e8fdd # v1.4.0` (または `swfz/slack-workflow-status@v1.4.0`)
- after: `Gamesight/slack-workflow-status@2e709ce51fd47f02b7221db8547e6e6f49f81f1d # v2.0.0`

input の書式 (`repo_token`, `slack_webhook_url`, `workflow_run`) は v1.4.0 と同じため、 各 step の `with:` は変更なし。

## 確認観点

- [ ] `actionlint` を通過していること
- [ ] Slack 通知が従来通り届くこと (CI 実行時に確認)
- [ ] 通知本文 (Actor / Branch / Workflow / Status / Duration) が従来通り表示されていること
- [ ] `Resource not accessible by integration` エラーが出ないこと (出た場合は notifier job に `permissions: actions: read, contents: read` を追記)

🤖 Generated with [Claude Code](https://claude.com/claude-code)