### PR TITLE
chore: kusaページの画像URLを新Deno DeployのURLへ更新

### DIFF
--- a/pages/kusa/[username].tsx
+++ b/pages/kusa/[username].tsx
@@ -183,7 +183,7 @@ const Detail = ({ username }: { username: string }) => {
 
 const Kusa = (props: Props) => {
   const username = props.username;
-  const imgUrl = `https://kusa-image.deno.dev/${username}`;
+  const imgUrl = `https://kusa-image.swfz.deno.net/${username}`;
   const siteUrl = `https://tools.swfz.io/kusa/${username}`;
   const title = `GitHub Contributions(kusa) in ${username}`;
   const desc = `Today: ${props.todayContributionCount}, Yesterday: ${props.yesterdayContributionCount}, Streak: ${props.currentStreak}, Coverage: ${props.coverage}%`;

--- a/pages/kusa/index.tsx
+++ b/pages/kusa/index.tsx
@@ -188,7 +188,7 @@ const KusaIndex: NextPage = () => {
                       </div>
                     </div>
                     <img
-                      src={`https://kusa-image.deno.dev/${username}`}
+                      src={`https://kusa-image.swfz.deno.net/${username}`}
                       alt={`${username}'s GitHub Contributions`}
                       className="w-full max-w-4xl rounded border"
                     />
@@ -200,7 +200,7 @@ const KusaIndex: NextPage = () => {
 
           <p className="mt-4 text-xs text-gray-600">
             💡 コントリビューション画像は
-            <a href="https://kusa-image.deno.dev/" className="text-blue-600 hover:underline">
+            <a href="https://kusa-image.swfz.deno.net/" className="text-blue-600 hover:underline">
               kusa-image
             </a>
             を使用しています


### PR DESCRIPTION
## 概要

`/kusa` ページで参照している kusa-image の画像URL・リンクを新Deno DeployのURL（`kusa-image.swfz.deno.net`）へ更新する。

## Why

- Deno Deploy Classic が 2026-07-20 に終了するため kusa-image を新Deno Deployへ移行した
- 旧 `kusa-image.deno.dev` は終了後に到達不能になるため、埋め込み画像が表示されなくなる

## How

- `pages/kusa/index.tsx` / `pages/kusa/[username].tsx` の `kusa-image.deno.dev` を `kusa-image.swfz.deno.net` に置換（画像src・リンク・OGP用imgUrl）

## 確認観点

- [x] prettier --check パス
- [x] eslint（errorなし、既存warningのみ）
- [x] 変更は文字列のみ、ロジック変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)