### PR TITLE
fix(kusa): contribution APIを新Deno Deployへ移行し、Search API失敗時の全体エラーを修正

### DIFF
--- a/e2e/kusa.spec.ts
+++ b/e2e/kusa.spec.ts
@@ -9,6 +9,15 @@ const mockGitHubEventsApi = async (page: Page) => {
       body: JSON.stringify(sampleEvents),
     });
   });
+
+  // Search APIは未認証だと10req/minで枯れるため常にモックする
+  await page.route('**/api.github.com/search/**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ total_count: 0, incomplete_results: false, items: [] }),
+    });
+  });
 };
 
 test.describe('Kusa ページ', () => {

--- a/e2e/kusa.spec.ts
+++ b/e2e/kusa.spec.ts
@@ -70,6 +70,14 @@ test.describe('Kusa ページ', () => {
     await expect(statsText).toBeVisible();
   });
 
+  test('Contribution APIが利用不可でもページが表示され統計はハイフンになる', async ({ page }) => {
+    await mockGitHubEventsApi(page);
+    // モックサーバーが deadapi に対して503を返す（旧APIのサービス停止相当）
+    await page.goto('/kusa/deadapi');
+    await expect(page.locator("text=deadapi's kusa")).toBeVisible();
+    await expect(page.locator('text=Today: -, Yesterday: -, Streak: -, Coverage: -%')).toBeVisible();
+  });
+
   test('OGメタタグのdescriptionに貢献統計が含まれる', async ({ page }) => {
     await mockGitHubEventsApi(page);
     await page.goto('/kusa/swfz');

--- a/e2e/mock-server.mjs
+++ b/e2e/mock-server.mjs
@@ -40,7 +40,15 @@ const server = http.createServer((req, res) => {
   const url = req.url || '';
 
   // Contribution API: /{username}.json?to=...
-  if (url.match(/\/[\w-]+\.json/)) {
+  const contributionMatch = url.match(/^\/([\w-]+)\.json/);
+  if (contributionMatch) {
+    // Simulate an unavailable upstream API for this username
+    if (contributionMatch[1] === 'deadapi') {
+      res.writeHead(503, { 'Content-Type': 'text/plain' });
+      res.end('Service Unavailable');
+      return;
+    }
+
     res.writeHead(200, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify(contributionResponse));
     return;

--- a/pages/kusa/[username].tsx
+++ b/pages/kusa/[username].tsx
@@ -22,17 +22,10 @@ type Props = {
   coverage: number | string;
 };
 
-const contributionApiUrl = process.env.CONTRIBUTION_API_URL || 'https://github-contributions-api.deno.dev';
+const contributionApiUrl = process.env.CONTRIBUTION_API_URL || 'https://forked-contributions-api.swfz.deno.net';
 
 const fetchContribution = async (url: string, username: string, to: string): Promise<(number | null)[]> => {
   const res = await fetch(`${url}/${username}.json?to=${to}`);
-
-  if (res.status !== 200 && url === contributionApiUrl) {
-    console.log('Failed fetch. Retry with another API');
-    console.log(await res.text());
-
-    return await fetchContribution('https://forked-gh-contributions-wt0jrc54gcqt.deno.dev', username, to);
-  }
 
   if (res.status !== 200) {
     console.log(await res.text());

--- a/src/components/kusa/contributions/__tests__/search-api.spec.ts
+++ b/src/components/kusa/contributions/__tests__/search-api.spec.ts
@@ -7,6 +7,10 @@ const mockFetch = (data: any, ok = true) => {
   });
 };
 
+const mockFetchRejection = () => {
+  global.fetch = jest.fn().mockRejectedValue(new TypeError('Failed to fetch'));
+};
+
 afterEach(() => {
   jest.restoreAllMocks();
 });
@@ -29,6 +33,12 @@ describe('fetchSearchPullRequests', () => {
     const result = await fetchSearchPullRequests('testuser', '2024-01-01');
     expect(result).toEqual([]);
   });
+
+  test('fetchが例外を投げても空配列を返す', async () => {
+    mockFetchRejection();
+
+    await expect(fetchSearchPullRequests('testuser', '2024-01-01')).resolves.toEqual([]);
+  });
 });
 
 describe('fetchSearchCommits', () => {
@@ -49,6 +59,12 @@ describe('fetchSearchCommits', () => {
     const result = await fetchSearchCommits('testuser', '2024-01-01');
     expect(result).toEqual([]);
   });
+
+  test('fetchが例外を投げても空配列を返す', async () => {
+    mockFetchRejection();
+
+    await expect(fetchSearchCommits('testuser', '2024-01-01')).resolves.toEqual([]);
+  });
 });
 
 describe('fetchSearchIssues', () => {
@@ -68,5 +84,11 @@ describe('fetchSearchIssues', () => {
 
     const result = await fetchSearchIssues('testuser', '2024-01-01');
     expect(result).toEqual([]);
+  });
+
+  test('fetchが例外を投げても空配列を返す', async () => {
+    mockFetchRejection();
+
+    await expect(fetchSearchIssues('testuser', '2024-01-01')).resolves.toEqual([]);
   });
 });

--- a/src/components/kusa/contributions/search-api.ts
+++ b/src/components/kusa/contributions/search-api.ts
@@ -11,35 +11,40 @@ type SearchResponse<T> = {
 
 const defaultSince = () => dayjs().subtract(1, 'month').format('YYYY-MM-DD');
 
+// Rate limited responses of the search API can be rejected by the browser before
+// they reach us (invalid CORS header), so a rejected fetch must not break the whole panel
+const fetchSearchItems = async <T>(url: string): Promise<T[]> => {
+  try {
+    const res = await fetch(url);
+
+    if (!res.ok) return [];
+
+    const json: SearchResponse<T> = await res.json();
+    return json.items;
+  } catch (e) {
+    console.log('[search-api] request failed:', e);
+    return [];
+  }
+};
+
 export const fetchSearchPullRequests = async (
   username: string,
   since: string = defaultSince(),
 ): Promise<SearchPullRequest[]> => {
   const q = `author:${username}+type:pr+created:>${since}`;
-  const res = await fetch(`${SEARCH_API_BASE}/issues?q=${q}&per_page=100&sort=created&order=desc`);
-
-  if (!res.ok) return [];
-
-  const json: SearchResponse<SearchPullRequest> = await res.json();
-  return json.items;
+  return await fetchSearchItems<SearchPullRequest>(
+    `${SEARCH_API_BASE}/issues?q=${q}&per_page=100&sort=created&order=desc`,
+  );
 };
 
 export const fetchSearchCommits = async (username: string, since: string = defaultSince()): Promise<SearchCommit[]> => {
   const q = `author:${username}+author-date:>${since}`;
-  const res = await fetch(`${SEARCH_API_BASE}/commits?q=${q}&per_page=100&sort=author-date&order=desc`);
-
-  if (!res.ok) return [];
-
-  const json: SearchResponse<SearchCommit> = await res.json();
-  return json.items;
+  return await fetchSearchItems<SearchCommit>(
+    `${SEARCH_API_BASE}/commits?q=${q}&per_page=100&sort=author-date&order=desc`,
+  );
 };
 
 export const fetchSearchIssues = async (username: string, since: string = defaultSince()): Promise<SearchIssue[]> => {
   const q = `author:${username}+type:issue+created:>${since}`;
-  const res = await fetch(`${SEARCH_API_BASE}/issues?q=${q}&per_page=100&sort=created&order=desc`);
-
-  if (!res.ok) return [];
-
-  const json: SearchResponse<SearchIssue> = await res.json();
-  return json.items;
+  return await fetchSearchItems<SearchIssue>(`${SEARCH_API_BASE}/issues?q=${q}&per_page=100&sort=created&order=desc`);
 };


### PR DESCRIPTION
## 概要

Deno Deploy Classic の停止で参照できなくなっていた kusa の contribution API を、新 Deno Deploy へ移したデプロイ先に差し替える。あわせて、その検証中に見つかった Search API 失敗時に Detail 全体が壊れる問題を修正する。

## why

### contribution API の移行漏れ

Deno Deploy Classic が 2026-07-20 に停止し、参照していた2つのエンドポイントが両方とも死んでいた。

```
https://github-contributions-api.deno.dev/swfz.json          → 404 DEPLOYMENT_NOT_FOUND
https://forked-gh-contributions-wt0jrc54gcqt.deno.dev/swfz   → 404 DEPLOYMENT_NOT_FOUND
  "Deno Deploy Classic was sunset on July 20, 2026 and no longer serves deployments."
```

primary（upstream のデプロイ）が落ちたときのフォールバック先も同じ Classic 上にあったため、`/kusa/[username]` の SSR は常に `[null, null]` を返し、Today / Yesterday / Streak / Coverage と OG の description がすべて `-` になっていた。

### Search API 失敗で Detail 全体がエラーになる

未認証の GitHub Search API は 10req/min で枯れる。その 403 応答は `Access-Control-Allow-Origin: *;` という不正な値を返すため、ブラウザは CORS 違反として `fetch` 自体を reject する。`search-api.ts` は `if (!res.ok) return []` で握る作りだったが、reject ではその分岐に到達せず例外が伝播し、React Query が error 状態になって Detail 全体が "Error" 表示になっていた（curl では正常な `*` が返るためブラウザからしか再現しない）。

## how

- `pages/kusa/[username].tsx` の参照先を、fork を新 Deno Deploy へデプロイした `https://forked-contributions-api.swfz.deno.net` に変更
  - 生きている代替が存在しなくなったため、フォールバックへの retry 分岐は削除
  - レスポンス形式は旧 API と同一（週ごとのネスト配列 / `to` パラメータ / CORS・cache ヘッダ）なので他の変更は不要
- `search-api.ts` の3関数を共通ヘルパ `fetchSearchItems` に集約し、fetch が reject しても空配列に倒す
- e2e に「contribution API が落ちていてもページは表示され統計は `-` になる」ケースを追加（モックサーバーが `deadapi` に 503 を返す）
- e2e の Search API 呼び出しをモックし、レート制限に依存しないようにした

## 確認観点

- [x] 移行先 API が旧 API と互換の応答を返すこと（週ごとのネスト配列 / `to` パラメータ / 最終要素が当日）
- [x] 実 API に対する SSR 疎通（`og:description` に実データが入ること）
  ```
  og:description" content="Today: 9, Yesterday: 7, Streak: 5, Coverage: 70%"
  ```
- [x] API 停止時にページが落ちず統計が `-` になること（e2e で固定）
- [x] Search API が例外を投げても空配列を返すこと（unit test 3件追加）
- [x] jest: 83 passed / 8 suites
- [x] playwright: kusa 9 passed（新規1件含む） / navigation・timer 8 passed
- [x] eslint: 0 errors（warning 28件はすべて既存）
- [x] prettier / tsc --noEmit ともにエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
